### PR TITLE
members-detail.html, members.html-링크 연결 시 url 계층 누락, 오류 부분 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
 </head>
 
 <body>
-    <a href="/members.html">팀원 목록</a>
-    <a href="/members-create-form.html">신규 팀원 등록</a>
-    <a href="/members-detail.html">팀원 상세 보기</a>
+    <a href="/generous/members.html">팀원 목록</a>
+    <a href="/generous/members-create-form.html">신규 팀원 등록</a>
+    <a href="/generous/members-detail.html">팀원 상세 보기</a>
 </body>
 
 </html>

--- a/members-detail.html
+++ b/members-detail.html
@@ -12,21 +12,21 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <!-- CSS 파일 -->
-    <link rel="stylesheet" href="members.css">
+    <link rel="stylesheet" href="/generous/css/members.css">
     <!-- 조각낸 HTML 파일 포함시켜주는 js -->
-    <script src="/static/js/includeHTML.js"></script>
+    <script src="/generous/js/includeHTML.js"></script>
 </head>
 
 <body>
     <!-- 헤더 include-html -->
-    <header include-html="/static/html/header.html" id="page-header"></header>
+    <header include-html="/generous/html/header.html" id="page-header"></header>
 
     <div class="grid-container">
         <div class="grid-half-box-gray"></div>
         <div class="grid-half-box">
             <div><span>우리의 관대한</span></div>
             <div><span>성명: ㅇㅇㅇ</span></div>
-            <div><a href="/members-create-form.html">MBTI: IIII</a></div>
+            <div><a href="/generous/members-create-form.html">MBTI: IIII</a></div>
         </div>
     </div>
 
@@ -48,7 +48,7 @@
     </div>
 
     <!-- 푸터 include-html -->
-    <footer include-html="/static/html/footer.html" id="page-footer"></footer>
+    <footer include-html="/generous/html/footer.html" id="page-footer"></footer>
 </body>
 
 <script>

--- a/members.html
+++ b/members.html
@@ -12,44 +12,44 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <!-- CSS 파일 -->
-    <link rel="stylesheet" href="members.css">
+    <link rel="stylesheet" href="/generous/css/members.css">
     <!-- 조각낸 HTML 파일 포함시켜주는 js -->
-    <script src="/static/js/includeHTML.js"></script>
+    <script src="/generous/js/includeHTML.js"></script>
 </head>
 
 <body>
     <!-- 헤더 include-html -->
-    <header include-html="/static/html/header.html" id="page-header"></header>
+    <header include-html="/generous/html/header.html" id="page-header"></header>
 
     <div class="grid-container">
         <div class="grid-half-box-gray"></div>
         <div class="grid-half-box">
             <div><span>관대하죠</span></div>
             <div><span>저희는 관대합니다.</span></div>
-            <div><a href="/members-create-form.html">여기를 눌러서 팀원을 입력</a></div>
+            <div><a href="/generous/members-create-form.html">여기를 눌러서 팀원을 입력</a></div>
         </div>
     </div>
 
     <div class="grid-container">
         <div class="grid-one-third-box">
-            <a href="/members-detail.html">card</a>
+            <a href="/generous/members-detail.html">card</a>
         </div>
         <div class="grid-one-third-box">
-            <a href="/members-detail.html">card</a>
+            <a href="/generous/members-detail.html">card</a>
         </div>
         <div class="grid-one-third-box">
-            <a href="/members-detail.html">card</a>
+            <a href="/generous/members-detail.html">card</a>
         </div>
         <div class="grid-one-third-box">
-            <a href="/members-detail.html">card</a>
+            <a href="/generous/members-detail.html">card</a>
         </div>
         <div class="grid-one-third-box">
-            <a href="/members-detail.html">card</a>
+            <a href="/generous/members-detail.html">card</a>
         </div>
     </div>
 
     <!-- 푸터 include-html -->
-    <footer include-html="/static/html/footer.html" id="page-footer"></footer>
+    <footer include-html="/generous/html/footer.html" id="page-footer"></footer>
 </body>
 
 <script>


### PR DESCRIPTION
현재 배포된 https://rugii913.github.io/generous/ 페이지를 보면
url 계층 오류(/generous 누락, 로컬에서 static 계층 삭제 작업 미반영)로 인해 페이지 간 링크가 제대로 되지 않고 있음
- url 계층을 수정하여, 배포된 페이지들에서 페이지 간 정상적인 연결을 위한 수정 작업임
- 검토 후 merge 요청