### PR TITLE
TypeError: callback is not a function 에러 해결

### DIFF
--- a/js/includeHTML.js
+++ b/js/includeHTML.js
@@ -32,6 +32,8 @@ function includeHTML(callback) {
         }
     }
     setTimeout(function () {
-        callback();
+        if(callback){
+            callback();
+        }
     }, 0);
 }

--- a/js/includeHTML.js
+++ b/js/includeHTML.js
@@ -32,7 +32,8 @@ function includeHTML(callback) {
         }
     }
     setTimeout(function () {
-        if(callback){
+        //check before calling it
+        if(typeof callback === "function"){
             callback();
         }
     }, 0);


### PR DESCRIPTION
## 발생한 에러
* includeHTML.js 파일에서 TypeError: callback is not a function 발생

## 에러 원인
* callback이 함수가 아닌 경우에 에러 발생

## 해결법
* callback이 함수일 경우에만 작동하도록 변경

##참조
* https://stackoverflow.com/questions/15905221/javascript-callback-function-throws-error-callback-is-not-a-function-in-firefo
* https://bobbyhadz.com/blog/javascript-typeerror-callback-is-not-a-function